### PR TITLE
Use Discord logo instead of wiki-bot

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -20,7 +20,7 @@
 	<div class="navbar">
 		<div style="width: 150px;"></div>
 		<a id="support" href="https://discord.gg/v77RTk5" target="_blank" alt="Support server">
-			<img class="avatar" src="https://cdn.discordapp.com/icons/464084451165732868/c6a8b9fc902b09545de8194a911e6045.png?size=128" alt="Support server" width="32" height="32">
+			<img class="avatar" src="https://discord.com/assets/f8389ca1a741a115313bede9ac02e2c0.svg" alt="Support server" width="32" height="32">
 			<span>Support server</span>
 		</a>
 		<a id="logout" href="/logout" alt="Logout">


### PR DESCRIPTION
Use Discord logo, because people will faster understand this will go to Discord.