### PR TITLE
Add 3 new wikis

### DIFF
--- a/util/default.json
+++ b/util/default.json
@@ -197,6 +197,24 @@
 			"regex": "((?:[a-z\\d-]{1,50}\\.)brickimedia\\.org)",
 			"articlePath": "/wiki/",
 			"scriptPath": "/w/"
+		},
+		{
+			"name": "librewiki.net",
+			"regex": "(librewiki\\.net)",
+			"articlePath": "/wiki/",
+			"scriptPath": "/"
+		},
+		{
+			"name": "femiwiki.com",
+			"regex": "((?:(?:www)\\.)?femiwiki\\.com)",
+			"articlePath": "/w/",
+			"scriptPath": "/"
+		},
+		{
+			"name": "revi.wiki",
+			"regex": "((?:(?:private)\\.)?revi\\.wiki)",
+			"articlePath": "/wiki/",
+			"scriptPath": "/w/"
 		}
 	]
 }


### PR DESCRIPTION
* librewiki and femiwiki is standalone wiki.
** librewiki.net does not resolve `www`.
** femiwiki.com resolves www.
* reviwiki is actually part of miraheze but on custom domain.
** reviwiki (public) might [move out of Miraheze](https://bugs.revi.xyz/T89) at some point but will keep same entry points. At least that's not now.

And yes, I am pretty bad at regex. Feel free to [trout](https://en.wikipedia.org/wiki/Template:Trout) me for errors.