### PR TITLE
Make status and issue link types translatable

### DIFF
--- a/cmds/minecraft/bug.js
+++ b/cmds/minecraft/bug.js
@@ -53,16 +53,16 @@ function minecraft_bug(lang, msg, args, title, cmd, querystring, fragment, react
 							var ward = ( link.outwardIssue ? 'outward' : 'inward' );
 							var issue = link[ward + 'Issue']; // looks for property (in|out)wardIssue
 							var linkType = link.type[ward];
-							var name = lang.get('minecraft.issue_link.' + linkType.toLowerCase().replace(' ', '_') | linkType) + ' ' + issue.key;
+							var name = lang.get('minecraft.issue_link.' + linkType.toLowerCase().replace(' ', '_'), issue.key) | linkType + ' ' + issue.key;
 							var status = issue.fields.status.name;
-							var value = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_') | status) + ': [' + issue.fields.summary.escapeFormatting() + '](' + baseBrowseUrl + issue.key + ')';
+							var value = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_')) | status + ': [' + issue.fields.summary.escapeFormatting() + '](' + baseBrowseUrl + issue.key + ')';
 							if ( embed.fields.length < 25 ) embed.addField( name, value );
 							else extralinks.push({name,value,inline:false});
 						} );
 						if ( extralinks.length ) embed.setFooter( lang.get('minecraft.more', extralinks.length.toLocaleString(lang.get('dateformat')), extralinks.length) );
 					}
 					var status = '**' + ( body.fields.resolution ? body.fields.resolution.name : body.fields.status.name ) + ':** ';
-					var translatedStatus = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_') | status);
+					var translatedStatus = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_')) | status;
 					var fixed = '';
 					if ( body.fields.resolution && body.fields.fixVersions && body.fields.fixVersions.length ) {
 						fixed = '\n' + lang.get('minecraft.fixed') + ' ' + body.fields.fixVersions.map( v => v.name ).join(', ');

--- a/cmds/minecraft/bug.js
+++ b/cmds/minecraft/bug.js
@@ -53,16 +53,16 @@ function minecraft_bug(lang, msg, args, title, cmd, querystring, fragment, react
 							var ward = ( link.outwardIssue ? 'outward' : 'inward' );
 							var issue = link[ward + 'Issue']; // looks for property (in|out)wardIssue
 							var linkType = link.type[ward];
-							var name = lang.get('minecraft.issue_link.' + linkType.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, ''), issue.key) | linkType + ' ' + issue.key;
+							var name = lang.get('minecraft.issue_link.' + linkType.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, ''), issue.key) || linkType + ' ' + issue.key;
 							var status = issue.fields.status.name;
-							var value = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, '')) | status + ': [' + issue.fields.summary.escapeFormatting() + '](' + baseBrowseUrl + issue.key + ')';
+							var value = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, '')) || status + ': [' + issue.fields.summary.escapeFormatting() + '](' + baseBrowseUrl + issue.key + ')';
 							if ( embed.fields.length < 25 ) embed.addField( name, value );
 							else extralinks.push({name,value,inline:false});
 						} );
 						if ( extralinks.length ) embed.setFooter( lang.get('minecraft.more', extralinks.length.toLocaleString(lang.get('dateformat')), extralinks.length) );
 					}
 					var status = '**' + ( body.fields.resolution ? body.fields.resolution.name : body.fields.status.name ) + ':** ';
-					var translatedStatus = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, '')) | status;
+					var translatedStatus = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, '')) || status;
 					var fixed = '';
 					if ( body.fields.resolution && body.fields.fixVersions && body.fields.fixVersions.length ) {
 						fixed = '\n' + lang.get('minecraft.fixed') + ' ' + body.fields.fixVersions.map( v => v.name ).join(', ');

--- a/cmds/minecraft/bug.js
+++ b/cmds/minecraft/bug.js
@@ -53,16 +53,17 @@ function minecraft_bug(lang, msg, args, title, cmd, querystring, fragment, react
 							var ward = ( link.outwardIssue ? 'outward' : 'inward' );
 							var issue = link[ward + 'Issue']; // looks for property (in|out)wardIssue
 							var linkType = link.type[ward];
-							var name = lang.get('minecraft.issue_link.' + linkType.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, ''), issue.key) || linkType + ' ' + issue.key;
+							var linkTypeLanguageKey = linkType.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, '');
+							var name = lang.get('minecraft.issue_link')[linkTypeLanguageKey] ? lang.get('minecraft.issue_link.' + linkTypeLanguageKey, issue.key) : linkType + ' ' + issue.key;
 							var status = issue.fields.status.name;
-							var value = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, '')) || status + ': [' + issue.fields.summary.escapeFormatting() + '](' + baseBrowseUrl + issue.key + ')';
+							var value = lang.get('minecraft.status')[status.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, '')] || status + ': [' + issue.fields.summary.escapeFormatting() + '](' + baseBrowseUrl + issue.key + ')';
 							if ( embed.fields.length < 25 ) embed.addField( name, value );
 							else extralinks.push({name,value,inline:false});
 						} );
 						if ( extralinks.length ) embed.setFooter( lang.get('minecraft.more', extralinks.length.toLocaleString(lang.get('dateformat')), extralinks.length) );
 					}
 					var status = '**' + ( body.fields.resolution ? body.fields.resolution.name : body.fields.status.name ) + ':** ';
-					var translatedStatus = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, '')) || status;
+					var translatedStatus = lang.get('minecraft.status')[status.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, '')] || status;
 					var fixed = '';
 					if ( body.fields.resolution && body.fields.fixVersions && body.fields.fixVersions.length ) {
 						fixed = '\n' + lang.get('minecraft.fixed') + ' ' + body.fields.fixVersions.map( v => v.name ).join(', ');

--- a/cmds/minecraft/bug.js
+++ b/cmds/minecraft/bug.js
@@ -53,16 +53,16 @@ function minecraft_bug(lang, msg, args, title, cmd, querystring, fragment, react
 							var ward = ( link.outwardIssue ? 'outward' : 'inward' );
 							var issue = link[ward + 'Issue']; // looks for property (in|out)wardIssue
 							var linkType = link.type[ward];
-							var name = lang.get('minecraft.issue_link.' + linkType.toLowerCase().replace(' ', '_'), issue.key) | linkType + ' ' + issue.key;
+							var name = lang.get('minecraft.issue_link.' + linkType.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, ''), issue.key) | linkType + ' ' + issue.key;
 							var status = issue.fields.status.name;
-							var value = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_')) | status + ': [' + issue.fields.summary.escapeFormatting() + '](' + baseBrowseUrl + issue.key + ')';
+							var value = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, '')) | status + ': [' + issue.fields.summary.escapeFormatting() + '](' + baseBrowseUrl + issue.key + ')';
 							if ( embed.fields.length < 25 ) embed.addField( name, value );
 							else extralinks.push({name,value,inline:false});
 						} );
 						if ( extralinks.length ) embed.setFooter( lang.get('minecraft.more', extralinks.length.toLocaleString(lang.get('dateformat')), extralinks.length) );
 					}
 					var status = '**' + ( body.fields.resolution ? body.fields.resolution.name : body.fields.status.name ) + ':** ';
-					var translatedStatus = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_')) | status;
+					var translatedStatus = lang.get('minecraft.status.' + status.toLowerCase().replace(' ', '_').replace(/[^a-z]/g, '')) | status;
 					var fixed = '';
 					if ( body.fields.resolution && body.fields.fixVersions && body.fields.fixVersions.length ) {
 						fixed = '\n' + lang.get('minecraft.fixed') + ' ' + body.fields.fixVersions.map( v => v.name ).join(', ');

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -396,7 +396,7 @@
         "more": "And $1 more.",
         "private": "**Private Issue**",
         "total": "$1 {{PLURAL:$2|issue|issues}} fixed",
-        "issueLink": {
+        "issue_link": {
             "duplicates": "duplicates $1",
             "relates_to": "relates to $1",
             "blocks": "blocks $1",
@@ -412,8 +412,8 @@
             "in_progress": "In Progress",
             "resolved": "Resolved",
             "reopned": "Reopened",
-            "closed": "closed",
-            "postponed": "postponed",
+            "closed": "Closed",
+            "postponed": "Postponed",
             "fixed": "Fixed",
             "wont_fix": "Won't Fix",
             "duplicate": "Duplicate",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -421,7 +421,7 @@
             "works_as_intended": "Works As Intended",
             "cannot_reproduce": "Cannot Reproduce",
             "invalid": "Invalid",
-            "awaiting_response", "Awaiting Response",
+            "awaiting_response": "Awaiting Response",
             "done": "Done"
         }
     },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -413,7 +413,16 @@
             "resolved": "Resolved",
             "reopned": "Reopened",
             "closed": "closed",
-            "postponed": "postponed"
+            "postponed": "postponed",
+            "fixed": "Fixed",
+            "wont_fix": "Won't Fix",
+            "duplicate": "Duplicate",
+            "incomplete": "Incomplete",
+            "works_as_intended": "Works As Intended",
+            "cannot_reproduce": "Cannot Reproduce",
+            "invalid": "Invalid",
+            "awaiting_response", "Awaiting Response",
+            "done": "Done"
         }
     },
     "overview": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -391,38 +391,49 @@
     },
     "minecraft": {
         "cmdpage": "Commands/",
-        "fixed": "Fixed Version:",
+        "fixed": "Fixed {{PLURAL:$2|Version|Versions}}:",
         "link": "https://minecraft.gamepedia.com/",
         "more": "And $1 more.",
         "private": "**Private Issue**",
         "total": "$1 {{PLURAL:$2|issue|issues}} fixed",
         "issue_link": {
-            "duplicates": "duplicates $1",
-            "relates_to": "relates to $1",
-            "blocks": "blocks $1",
-            "is_blocked_by": "is blocked by $1",
-            "testing_discovered": "testing discovered $1",
-            "discovered_while_testing": "discovered while testing $1",
-            "clones": "clones $1",
-            "is_cloned_by": "is cloned by $1",
-            "is_duplicated_by": "is duplicated by $1"
+            "Blocks": {
+                "inward": "is blocked by $1",
+                "outward": "blocks $1"
+            },
+            "Bonfire Testing": {
+                "inward": "discovered while testing $1",
+                "outward": "testing discovered $1"
+            },
+            "Cloners": {
+                "inward": "is cloned by $1",
+                "outward": "clones $1"
+            },
+            "Duplicate": {
+                "inward": "is duplicated by $1",
+                "outward": "duplicates $1"
+            },
+            "Relates": {
+                "inward": "relates to $1",
+                "outward": "relates to $1"
+            }
         },
         "status": {
-            "open": "Open",
-            "in_progress": "In Progress",
-            "resolved": "Resolved",
-            "reopned": "Reopened",
-            "closed": "Closed",
-            "postponed": "Postponed",
-            "fixed": "Fixed",
-            "wont_fix": "Won't Fix",
-            "duplicate": "Duplicate",
-            "incomplete": "Incomplete",
-            "works_as_intended": "Works As Intended",
-            "cannot_reproduce": "Cannot Reproduce",
-            "invalid": "Invalid",
-            "awaiting_response": "Awaiting Response",
-            "done": "Done"
+            "Awaiting Response": "Awaiting Response",
+            "Cannot Reproduce": "Cannot Reproduce",
+            "Closed": "Closed",
+            "Done": "Done",
+            "Duplicate": "Duplicate",
+            "Fixed": "Fixed",
+            "In Progress": "In Progress",
+            "Incomplete": "Incomplete",
+            "Invalid": "Invalid",
+            "Open": "Open",
+            "Postponed": "Postponed",
+            "Reopened": "Reopened",
+            "Resolved": "Resolved",
+            "Won't Fix": "Won't Fix",
+            "Works As Intended": "Works As Intended"
         }
     },
     "overview": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -395,7 +395,26 @@
         "link": "https://minecraft.gamepedia.com/",
         "more": "And $1 more.",
         "private": "**Private Issue**",
-        "total": "$1 {{PLURAL:$2|issue|issues}} fixed"
+        "total": "$1 {{PLURAL:$2|issue|issues}} fixed",
+        "issueLink": {
+            "duplicates": "duplicates $1"
+            "relates_to": "relates to $1"
+            "blocks": "blocks $1"
+            "is_blocked_by": "is blocked by $1"
+            "testing_discovered": "testing discovered $1"
+            "discovered_while_testing": "discovered while testing $1"
+            "clones": "clones $1"
+            "is_cloned_by": "is cloned by $1"
+            "is_duplicated_by": "is duplicated by $1"
+        },
+        "status": {
+            "open": "Open",
+            "in_progress": "In Progress",
+            "resolved": "Resolved",
+            "reopned": "Reopened",
+            "closed": "closed",
+            "postponed": "postponed"
+        }
     },
     "overview": {
         "articles": "Articles:",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -397,14 +397,14 @@
         "private": "**Private Issue**",
         "total": "$1 {{PLURAL:$2|issue|issues}} fixed",
         "issueLink": {
-            "duplicates": "duplicates $1"
-            "relates_to": "relates to $1"
-            "blocks": "blocks $1"
-            "is_blocked_by": "is blocked by $1"
-            "testing_discovered": "testing discovered $1"
-            "discovered_while_testing": "discovered while testing $1"
-            "clones": "clones $1"
-            "is_cloned_by": "is cloned by $1"
+            "duplicates": "duplicates $1",
+            "relates_to": "relates to $1",
+            "blocks": "blocks $1",
+            "is_blocked_by": "is blocked by $1",
+            "testing_discovered": "testing discovered $1",
+            "discovered_while_testing": "discovered while testing $1",
+            "clones": "clones $1",
+            "is_cloned_by": "is cloned by $1",
             "is_duplicated_by": "is duplicated by $1"
         },
         "status": {


### PR DESCRIPTION
Issue link types can be translated using (`minecraft.issue_link.<link_type>`)
Statuses can be translated using (`minecraft.status.<status_or_resolution>`)

Note that the link type values are based on what's returned by the api, so in case the name of a link from the api changes, this will break any translations.
In case a translation lookup doesn't return a valid value, the string that's returned by the api is used instead.

This is completely untested cause I'm too lazy to setup a bot account and try to figure out how to run this bot for testing. So you might want to take a look at this and verify it actually works before merging.